### PR TITLE
feat: Display recent analysis on dashboard

### DIFF
--- a/src/hooks/useRecentAnalysis.jsx
+++ b/src/hooks/useRecentAnalysis.jsx
@@ -1,0 +1,53 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useAuth } from '@/contexts/AuthContext.jsx';
+import { supabase } from '@/lib/supabaseClient.js';
+
+const useRecentAnalysis = () => {
+  const [recentAnalysis, setRecentAnalysis] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const { user } = useAuth();
+
+  const fetchRecentAnalysis = useCallback(async () => {
+    if (!user) {
+      setLoading(false);
+      // setError(new Error("User not authenticated.")); // Optional: set an error or just return
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const { data, error: supabaseError } = await supabase
+        .from('analyses')
+        .select('*')
+        .eq('user_id', user.id)
+        .order('upload_date', { ascending: false })
+        .limit(1);
+
+      if (supabaseError) {
+        throw supabaseError;
+      }
+
+      if (data && data.length > 0) {
+        setRecentAnalysis(data[0]);
+      } else {
+        setRecentAnalysis(null); // No recent analysis found
+      }
+    } catch (err) {
+      console.error('Error fetching recent analysis:', err);
+      setError(err);
+    } finally {
+      setLoading(false);
+    }
+  }, [user, supabase]); // Added supabase as a dependency for useCallback
+
+  useEffect(() => {
+    fetchRecentAnalysis();
+  }, [user, fetchRecentAnalysis]); // user dependency is indirect via fetchRecentAnalysis
+
+  return { recentAnalysis, loading, error, fetchRecentAnalysis };
+};
+
+export default useRecentAnalysis;

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -60,6 +60,16 @@
       "signInHere": "Sign in here",
       "signIn": "Sign In",
       "redirectToDashboard": "Redirecting to dashboard...",
-      "comingSoon": "Coming soon"
+      "comingSoon": "Coming soon",
+      "errorFetchingRecentAnalysis": "Error Fetching Recent Analysis",
+      "tryAgain": "Try Again",
+      "noRecentAnalysisFound": "No Recent Analyses Found",
+      "startNewAnalysisPrompt": "Get started by performing your first analysis.",
+      "patientNameLabel": "Patient Name",
+      "analysisTypeLabel": "Analysis Type",
+      "dateLabel": "Date",
+      "viewReportButton": "View Report",
+      "homeRecentActivityTitle": "Recent Activity",
+      "homeRecentActivityDescription": "Your latest analysis will appear here."
     }
   

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -60,6 +60,16 @@
       "signInHere": "Inicia sesión aquí",
       "signIn": "Iniciar Sesión",
       "redirectToDashboard": "Redirigiendo al panel...",
-      "comingSoon": "Próximamente"
+      "comingSoon": "Próximamente",
+      "errorFetchingRecentAnalysis": "Error al Cargar Análisis Reciente",
+      "tryAgain": "Intentar de Nuevo",
+      "noRecentAnalysisFound": "No se Encontraron Análisis Recientes",
+      "startNewAnalysisPrompt": "Comienza realizando tu primer análisis.",
+      "patientNameLabel": "Nombre del Paciente",
+      "analysisTypeLabel": "Tipo de Análisis",
+      "dateLabel": "Fecha",
+      "viewReportButton": "Ver Informe",
+      "homeRecentActivityTitle": "Actividad Reciente",
+      "homeRecentActivityDescription": "Tu último análisis aparecerá aquí."
     }
   

--- a/src/locales/pt/common.json
+++ b/src/locales/pt/common.json
@@ -60,6 +60,16 @@
       "signInHere": "Entre aqui",
       "signIn": "Entrar",
       "redirectToDashboard": "Redirecionando para o painel...",
-      "comingSoon": "Em breve"
+      "comingSoon": "Em breve",
+      "errorFetchingRecentAnalysis": "Erro ao Carregar Análise Recente",
+      "tryAgain": "Tentar Novamente",
+      "noRecentAnalysisFound": "Nenhuma Análise Recente Encontrada",
+      "startNewAnalysisPrompt": "Comece realizando sua primeira análise.",
+      "patientNameLabel": "Nome do Paciente",
+      "analysisTypeLabel": "Tipo de Análise",
+      "dateLabel": "Data",
+      "viewReportButton": "Ver Relatório",
+      "homeRecentActivityTitle": "Atividade Recente",
+      "homeRecentActivityDescription": "Sua última análise aparecerá aqui."
     }
   

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -3,14 +3,16 @@
     import { Link } from 'react-router-dom';
     import { Button } from '@/components/ui/button.jsx';
     import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card.jsx';
-    import { FilePlus2, History, BarChart3, Zap, User, Activity } from 'lucide-react';
+    import { FilePlus2, History, BarChart3, Zap, User, Activity, Loader2, AlertTriangle, FileText, CalendarDays, PawPrint, Microscope } from 'lucide-react';
     import { motion } from 'framer-motion';
     import { useAuth } from '@/contexts/AuthContext.jsx';
+    import { useRecentAnalysis } from '@/hooks/useRecentAnalysis.jsx';
     import { useTranslation } from '@/contexts/TranslationContext.jsx';
 
     const HomePage = () => {
       const { user } = useAuth();
       const { t } = useTranslation();
+      const { recentAnalysis, loading, error, fetchRecentAnalysis } = useRecentAnalysis();
 
       const cardVariants = {
         hidden: { opacity: 0, y: 20 },
@@ -101,10 +103,61 @@
               </div>
               <CardDescription className="text-slate-600 dark:text-slate-400">{t('homeRecentActivityDescription')}</CardDescription>
             </CardHeader>
-            <CardContent>
-              <p className="text-slate-500 dark:text-slate-400">
-                {t('homeRecentActivityPlaceholder')}
-              </p>
+            <CardContent className="space-y-4">
+              {loading && (
+                <div className="flex justify-center items-center py-6">
+                  <Loader2 className="animate-spin h-10 w-10 text-primary" />
+                </div>
+              )}
+              {error && (
+                <div className="flex flex-col items-center text-center py-6">
+                  <AlertTriangle className="h-10 w-10 text-red-500 mb-3" />
+                  <p className="text-red-500 font-medium">{t('errorFetchingRecentAnalysis')}</p>
+                  <p className="text-slate-500 dark:text-slate-400 text-sm">{error.message}</p>
+                  <Button variant="outline" size="sm" onClick={fetchRecentAnalysis} className="mt-4">
+                    {t('tryAgain')}
+                  </Button>
+                </div>
+              )}
+              {!loading && !error && !recentAnalysis && (
+                <div className="flex flex-col items-center text-center py-6">
+                  <FileText className="h-10 w-10 text-slate-400 mb-3" />
+                  <p className="text-slate-500 dark:text-slate-400 font-medium">{t('noRecentAnalysisFound')}</p>
+                  <p className="text-sm text-slate-400 dark:text-slate-500">{t('startNewAnalysisPrompt')}</p>
+                  <Button asChild className="mt-4">
+                    <Link to="/new-analysis">{t('newAnalysisButton')}</Link>
+                  </Button>
+                </div>
+              )}
+              {!loading && !error && recentAnalysis && (
+                <div className="space-y-3">
+                  <div className="flex items-center space-x-3">
+                    <PawPrint className="h-5 w-5 text-primary flex-shrink-0" />
+                    <span className="text-slate-700 dark:text-slate-300">
+                      {t('patientNameLabel')}: <strong className="font-semibold">{recentAnalysis.patient_name || t('notAvailable')}</strong>
+                    </span>
+                  </div>
+                  <div className="flex items-center space-x-3">
+                    <Microscope className="h-5 w-5 text-sky-500 flex-shrink-0" />
+                    <span className="text-slate-700 dark:text-slate-300">
+                      {t('analysisTypeLabel')}: <strong className="font-semibold">{recentAnalysis.analysis_type || t('notAvailable')}</strong>
+                    </span>
+                  </div>
+                  <div className="flex items-center space-x-3">
+                    <CalendarDays className="h-5 w-5 text-amber-500 flex-shrink-0" />
+                    <span className="text-slate-700 dark:text-slate-300">
+                      {t('dateLabel')}: <strong className="font-semibold">{new Date(recentAnalysis.upload_date).toLocaleDateString()}</strong>
+                    </span>
+                  </div>
+                  <div className="pt-3">
+                    <Button asChild className="w-full md:w-auto shadow-md hover:shadow-lg transition-shadow">
+                      <Link to={`/history/${recentAnalysis.id}`}>
+                        <FileText className="mr-2 h-4 w-4" /> {t('viewReportButton')}
+                      </Link>
+                    </Button>
+                  </div>
+                </div>
+              )}
             </CardContent>
           </Card>
 


### PR DESCRIPTION
This commit introduces a 'Recent Activity' section on the HomePage (Dashboard) that displays your most recent analysis.

Key changes:
- Created a new hook `useRecentAnalysis.jsx` to fetch the latest analysis for the logged-in user from Supabase, limited to one record.
- Integrated this hook into `src/pages/HomePage.jsx`.
- The 'Recent Activity' card now dynamically displays:
    - A loading state while data is being fetched.
    - An error message if fetching fails, with a 'Try Again' option.
    - A message prompting to create a new analysis if none exists.
    - Key details of the most recent analysis, including patient name, analysis type, and date, with a button to view the full report.
- Added new translation keys for all new UI text elements in English, Spanish, and Portuguese to ensure internationalization.
- Icons are used to enhance the UI for different states and data points.